### PR TITLE
Check for $dist == "redhat" in installEPTIDSupport()

### DIFF
--- a/files/script.functions.sh
+++ b/files/script.functions.sh
@@ -490,11 +490,11 @@ installEPTIDSupport ()
                         test=`dpkg -s mysql-server > /dev/null 2>&1`
                         isInstalled=$?
 
-                elif [ "$dist" == "centos" -a "$redhatDist" == "6" ]; then
+                elif [ "$dist" == "centos" -o "$dist" == "redhat" ] && [ "$redhatDist" == "6" ]; then
                         [ -f /etc/init.d/mysqld ]
                         isInstalled=$?
 
-                elif [ "$dist" == "centos" -a "$redhatDist" == "7" ]; then
+                elif [ "$dist" == "centos" -o "$dist" == "redhat" ] && [ "$redhatDist" == "7" ]; then
                         #Add Oracle repos
                         if [ ! -z "`rpm -q mysql-community-release | grep ' is not installed'`" ]; then
 

--- a/files/script.functions.sh
+++ b/files/script.functions.sh
@@ -1458,7 +1458,7 @@ restartJettyService ()
         iptables -I INPUT -p tcp -m state --state NEW -m tcp --dport 8443 -j ACCEPT
         iptables -t nat -A PREROUTING -p tcp --dport 443 -j REDIRECT --to-port 7443
         
-        if [ "${dist}" == "centos" ]; then
+        if [ "${dist}" == "centos" -o "${dist}" == "redhat" ]; then
 		iptables-save > /etc/sysconfig/iptables
         elif [ "${dist}" == "ubuntu" ]; then
 	 	iptables-save > /etc/iptables/rules.v4


### PR DESCRIPTION
When checking whether or not MySQL Server is installed, support the
case where $dist == “redhat”.

installEPTIDSupport() sets isInstalled with a series of if-else
statements for when $dist is “ubuntu” or “centos”. On RHEL, $dist is
“redhat”, and doesn’t match any of the conditionals. This results in
isInstalled not being set with a 0 or 1 value, generating a “integer
expression expected” error when run, and MySQL Server not being
installed and configured.